### PR TITLE
DD-7 Only checking scripts that exist

### DIFF
--- a/src/Context/ProtocolContext.php
+++ b/src/Context/ProtocolContext.php
@@ -103,7 +103,10 @@ class ProtocolContext implements MinkAwareContext {
 
     foreach ($urls as $url) {
       $session->visit($url);
-      $this->assertResponseNotContainsHttpUrls();
+      // Only check scripts that exist.
+      if ($session->getStatusCode() == 200) {
+        $this->assertResponseNotContainsHttpUrls();
+      }
     }
 
     // Go back to original page.


### PR DESCRIPTION
We need to ensure we only check valid JS paths. The current implementation assumes that all `requirejs` paths are files, however some are directories.

We can't check the local file path as we'd need to make assumptions about where the Drupal root is relative to where Behat tests are running, or make this context Drupal aware, which seems like an unnecessary dependency.

I've added a check for a 200 status before checking the contents of the JS as this seems like the simplest fix for now.